### PR TITLE
Add body pose estimation module

### DIFF
--- a/Assets~/Profiles/DefaultCameraServiceProfile.asset
+++ b/Assets~/Profiles/DefaultCameraServiceProfile.asset
@@ -22,13 +22,21 @@ MonoBehaviour:
       runtimePlatforms:
       - reference: 9869b29e-43bb-44cc-ae49-eb5c913263f9
   - instancedType:
+      reference: 92fef470-917e-4d54-9099-6c3e857b2bbc
+    name: Default Body Pose Provider Module
+    priority: 1
+    profile: {fileID: 0}
+    platformEntries:
+      runtimePlatforms:
+      - reference: 9869b29e-43bb-44cc-ae49-eb5c913263f9
+  - instancedType:
       reference: a68682d3-3e9d-4d56-8a32-9805f58928f8
     name: Camera Bounds Module
-    priority: 0
+    priority: 1
     profile: {fileID: 0}
     platformEntries:
       runtimePlatforms:
       - reference: 9869b29e-43bb-44cc-ae49-eb5c913263f9
   isRigPersistent: 1
   resetCameraToOrigin: 0
-  rigPrefab: {fileID: 6074567058768481976, guid: 3d755ceced433da43a06ddaabfe73b3c, type: 3}
+  rigPrefab: {fileID: 1634786522418503189, guid: aae20b1f893489b4797fc46eacbb4101, type: 3}

--- a/Assets~/StandardAssets/Prefabs/XRCameraRig.prefab
+++ b/Assets~/StandardAssets/Prefabs/XRCameraRig.prefab
@@ -97,9 +97,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0

--- a/Assets~/StandardAssets/Prefabs/XRPlayerController.prefab
+++ b/Assets~/StandardAssets/Prefabs/XRPlayerController.prefab
@@ -53,9 +53,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -130,9 +138,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1634786521743085562}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.25
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &824352232160900368
@@ -170,10 +186,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1634786521743085562}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 0
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -235,8 +262,6 @@ MonoBehaviour:
   controller: {fileID: 1449923283234235447}
   bodyTransform: {fileID: 9042037184276085410}
   bodyDiameter: 1
-  startRotateBodyAngle: 45
-  angleRotateBodySpeed: 20
   gravityMode: 0
 --- !u!54 &4329863972925498748
 Rigidbody:
@@ -245,10 +270,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1634786522418503189}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 0
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -262,9 +298,17 @@ CharacterController:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1634786522418503189}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Height: 1.35
   m_Radius: 0.5
   m_SlopeLimit: 45

--- a/Runtime/Interfaces/IBodyPoseProviderModule.cs
+++ b/Runtime/Interfaces/IBodyPoseProviderModule.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace RealityToolkit.CameraService.Interfaces
+{
+    /// <summary>
+    /// Provides an estimated or tracked body pose for the <see cref="IXRPlayerController"/>.
+    /// </summary>
+    public interface IBodyPoseProviderModule : ICameraServiceModule
+    {
+        /// <summary>
+        /// The up to date body pose.
+        /// </summary>
+        Pose Pose { get; }
+    }
+}

--- a/Runtime/Interfaces/IBodyPoseProviderModule.cs.meta
+++ b/Runtime/Interfaces/IBodyPoseProviderModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1666c90485532142be7da63501bf198
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Modules/DefaultBodyPoseProviderModule.cs
+++ b/Runtime/Modules/DefaultBodyPoseProviderModule.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.ServiceFramework.Attributes;
+using RealityCollective.ServiceFramework.Definitions;
+using RealityCollective.ServiceFramework.Definitions.Platforms;
+using RealityCollective.ServiceFramework.Modules;
+using RealityToolkit.CameraService.Interfaces;
+using UnityEngine;
+
+namespace RealityToolkit.CameraService.Modules
+{
+    /// <summary>
+    /// Default <see cref="IBodyPoseProviderModule"/> implementation that provides a very basic
+    /// estimation for the body pose.
+    /// </summary>
+    [RuntimePlatform(typeof(AllPlatforms))]
+    [System.Runtime.InteropServices.Guid("92fef470-917e-4d54-9099-6c3e857b2bbc")]
+    public class DefaultBodyPoseProviderModule : BaseServiceModule, IBodyPoseProviderModule
+    {
+        /// <inheritdoc />
+        public DefaultBodyPoseProviderModule(string name, uint priority, BaseProfile profile, ICameraService parentService)
+            : base(name, priority, profile, parentService)
+        {
+            cameraService = parentService;
+        }
+
+        private readonly ICameraService cameraService;
+        private IXRPlayerController playerController;
+        private const float rotateTowardsSpeed = 50f;
+        private const float thresholdAngle = 30f;
+        private const float largeAngleBoostThreshold = 45f;
+        private const float largeAngleBoostMultiplier = 2f;
+        private bool shouldReturnToIdle;
+
+        /// <inheritdoc />
+        public override void Initialize()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            playerController = cameraService.CameraRig as IXRPlayerController;
+            if (playerController == null)
+            {
+                Debug.LogError($"{nameof(DefaultBodyPoseProviderModule)} works only with {nameof(IXRPlayerController)} implementations.");
+                IsEnabled = false;
+            }
+        }
+
+        /// <inheritdoc />
+        public Pose Pose
+        {
+            get
+            {
+                if (!IsEnabled)
+                {
+                    return Pose.identity;
+                }
+
+                var bodyPosition = playerController.CameraTransform.position;
+                bodyPosition.y = playerController.RigTransform.position.y;
+                var bodyRotation = playerController.BodyTransform.rotation;
+
+                var angle = Vector3.Angle(playerController.BodyTransform.forward, playerController.CameraTransform.forward);
+                if (angle > thresholdAngle || shouldReturnToIdle)
+                {
+                    var targetRotation = Quaternion.LookRotation(playerController.CameraTransform.forward, Vector3.up);
+                    var speed = angle > largeAngleBoostThreshold ? largeAngleBoostMultiplier * rotateTowardsSpeed : rotateTowardsSpeed;
+                    bodyRotation = Quaternion.RotateTowards(playerController.BodyTransform.rotation, targetRotation, speed * Time.deltaTime);
+                    shouldReturnToIdle = angle > 0;
+                }
+
+                return new Pose(bodyPosition, bodyRotation);
+            }
+        }
+    }
+}

--- a/Runtime/Modules/DefaultBodyPoseProviderModule.cs.meta
+++ b/Runtime/Modules/DefaultBodyPoseProviderModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 587405f3a27a17c4e926288c5c55ac5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

In the recent PR I actually forgot to add the body pose estimation and the body was not following along with the rig.
This PR adds a new `IBodyPoseProviderModule` and a default implementation `DefaultBodyPoseProviderModule` that estimates the body using a primitive approach based on the camera's pose, which is good enough in many cases.

Since some platforms have body estimation APIs, such as the Meta Presence Platform, those platforms can provide their own implementation to improve the estimate.
